### PR TITLE
feat(bsc-parse): init module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 members = [
-  "bsc", "bsc-lexer",
+  "bsc", "bsc-lexer", "bsc-parse",
 ]
 resolver = "3"

--- a/bsc-lexer/src/lib.rs
+++ b/bsc-lexer/src/lib.rs
@@ -60,7 +60,7 @@ pub enum StringLiteralCharset {
 #[derive(Clone, Debug, PartialEq)]
 pub struct StringLiteral {
     charset: StringLiteralCharset,
-    value: String,
+    pub value: String,
 }
 
 /// An enum representing the different kinds of tokens.

--- a/bsc-parse/Cargo.toml
+++ b/bsc-parse/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2024"
 lalrpop = "0.22.1"
 
 [dependencies]
+bsc-lexer = { path = "../bsc-lexer" }
 lalrpop-util = { version = "0.22.1", features = ["lexer", "unicode"] }

--- a/bsc-parse/Cargo.toml
+++ b/bsc-parse/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bsc-parse"
+version = "0.1.0"
+edition = "2024"
+
+[build-dependencies]
+lalrpop = "0.22.1"
+
+[dependencies]
+lalrpop-util = { version = "0.22.1", features = ["lexer", "unicode"] }

--- a/bsc-parse/build.rs
+++ b/bsc-parse/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    lalrpop::process_src().unwrap();
+}

--- a/bsc-parse/src/ast.rs
+++ b/bsc-parse/src/ast.rs
@@ -1,0 +1,352 @@
+use std::fmt::Debug;
+use std::fmt::{self, Display};
+use std::ops::{Deref, DerefMut, Range};
+
+pub type Span = Range<usize>;
+
+pub struct P<T: ?Sized> {
+    ptr: Box<T>,
+}
+
+#[allow(non_snake_case, reason = "lowercase 'p' is ugly")]
+pub fn P<T: 'static>(value: T) -> P<T> {
+    P {
+        ptr: Box::new(value),
+    }
+}
+
+impl<T: ?Sized> Deref for P<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.ptr
+    }
+}
+
+impl<T: ?Sized> DerefMut for P<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.ptr
+    }
+}
+
+impl<T: ?Sized + Debug> Debug for P<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.ptr, f)
+    }
+}
+
+impl<T: 'static + Clone> Clone for P<T> {
+    fn clone(&self) -> Self {
+        P((**self).clone())
+    }
+}
+
+impl<T: Display> fmt::Display for P<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.ptr.fmt(f)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Constant {
+    Integer(u64),
+    Float(f64),
+}
+
+impl fmt::Display for Constant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Constant::Integer(n) => write!(f, "{n}"),
+            Constant::Float(n) => write!(f, "{n}"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum StringLiteral {
+    StringLiteral(String),
+    FuncName,
+}
+
+impl fmt::Display for StringLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StringLiteral::StringLiteral(s) => write!(f, r#""{s}""#),
+            StringLiteral::FuncName => write!(f, "__func__"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum AssignOpKind {
+    Assign,           // =
+    AssignMul,        // *=
+    AssignDiv,        // /=
+    AssignMod,        // %=
+    AssignAdd,        // +=
+    AssignSub,        // -=
+    AssignShiftLeft,  // <<=
+    AssignShiftRight, // >>=
+    AssignBitwiseAnd, // &=
+    AssignBitwiseOr,  // |=
+    AssignXor,        // ^=
+}
+
+impl fmt::Display for AssignOpKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AssignOpKind::Assign => write!(f, "="),
+            AssignOpKind::AssignMul => write!(f, "*="),
+            AssignOpKind::AssignDiv => write!(f, "/="),
+            AssignOpKind::AssignMod => write!(f, "%="),
+            AssignOpKind::AssignAdd => write!(f, "+="),
+            AssignOpKind::AssignSub => write!(f, "-="),
+            AssignOpKind::AssignShiftLeft => write!(f, "<<="),
+            AssignOpKind::AssignShiftRight => write!(f, ">>="),
+            AssignOpKind::AssignBitwiseAnd => write!(f, "&="),
+            AssignOpKind::AssignBitwiseOr => write!(f, "|="),
+            AssignOpKind::AssignXor => write!(f, "^="),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum BinOpKind {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    LogicalOr,
+    LogicalAnd,
+    BitwiseOr,
+    BitwiseAnd,
+    BitwiseXor,
+    Eq,
+    Neq,
+    Less,
+    Great,
+    LessEq,
+    GreatEq,
+    ShiftLeft,
+    ShiftRight,
+}
+
+impl fmt::Display for BinOpKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BinOpKind::Add => write!(f, "+"),
+            BinOpKind::Sub => write!(f, "-"),
+            BinOpKind::Mul => write!(f, "*"),
+            BinOpKind::Div => write!(f, "/"),
+            BinOpKind::Mod => write!(f, "%"),
+            BinOpKind::LogicalOr => write!(f, "||"),
+            BinOpKind::LogicalAnd => write!(f, "&&"),
+            BinOpKind::BitwiseOr => write!(f, "|"),
+            BinOpKind::BitwiseAnd => write!(f, "&"),
+            BinOpKind::BitwiseXor => write!(f, "^"),
+            BinOpKind::Eq => write!(f, "=="),
+            BinOpKind::Neq => write!(f, "!="),
+            BinOpKind::Less => write!(f, "<"),
+            BinOpKind::Great => write!(f, ">"),
+            BinOpKind::LessEq => write!(f, "<="),
+            BinOpKind::GreatEq => write!(f, ">="),
+            BinOpKind::ShiftLeft => write!(f, "<<"),
+            BinOpKind::ShiftRight => write!(f, ">>"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum UnaryOpKind {
+    PreInc,
+    PreDec,
+    PostInc,
+    PostDec,
+    Ref,
+    Deref,
+    Plus,
+    Minus,
+    Neg,
+    Not,
+    Sizeof,
+}
+
+impl fmt::Display for UnaryOpKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PreInc | Self::PostInc => write!(f, "++"),
+            Self::PreDec | Self::PostDec => write!(f, "--"),
+            Self::Ref => write!(f, "&"),
+            Self::Deref => write!(f, "*"),
+            Self::Plus => write!(f, "+"),
+            Self::Minus => write!(f, "-"),
+            Self::Neg => write!(f, "~"),
+            Self::Not => write!(f, "!"),
+            Self::Sizeof => write!(f, "sizeof"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum AssociationTy {
+    Default,
+    Ty(P<Ty>),
+}
+
+impl fmt::Display for AssociationTy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AssociationTy::Default => write!(f, "default"),
+            AssociationTy::Ty(p) => write!(f, "{p}"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GenericAssociation {
+    pub span: Span,
+    pub association_ty: AssociationTy,
+    pub expr: P<Expr>,
+}
+
+impl fmt::Display for GenericAssociation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} : ({})", self.association_ty, self.expr)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum TypeSpecifier {
+    Void,
+    Char,
+    Short,
+    Int,
+    Long,
+    Float,
+    Double,
+    Signed,
+    Unsigned,
+    Bool,
+    Complex,
+    Imaginary,
+    // TODO: Atomic
+    // TODO: struct and union
+    // TODO: enum
+    // TODO: typedef name
+}
+
+impl fmt::Display for TypeSpecifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Void => write!(f, "void"),
+            Self::Char => write!(f, "char"),
+            Self::Short => write!(f, "short"),
+            Self::Int => write!(f, "int"),
+            Self::Long => write!(f, "long"),
+            Self::Float => write!(f, "float"),
+            Self::Double => write!(f, "double"),
+            Self::Signed => write!(f, "signed"),
+            Self::Unsigned => write!(f, "unsigned"),
+            Self::Bool => write!(f, "_Bool"),
+            Self::Complex => write!(f, "_Complex"),
+            Self::Imaginary => write!(f, "_Imaginary"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum TypeQualifier {
+    Const,
+    Restrict,
+    Volatile,
+    Atomic,
+}
+
+impl fmt::Display for TypeQualifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TypeQualifier::Const => write!(f, "const"),
+            TypeQualifier::Restrict => write!(f, "restrict"),
+            TypeQualifier::Volatile => write!(f, "volatile"),
+            TypeQualifier::Atomic => write!(f, "_Atomic"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SpecifierQualifierList {
+    pub specifiers: Vec<P<TypeSpecifier>>,
+    pub qualifiers: Vec<P<TypeQualifier>>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Indirection {
+    pub qualifiers: Vec<P<TypeQualifier>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Pointer {
+    pub indirections: Vec<Indirection>,
+}
+
+#[derive(Clone, Debug)]
+pub enum AbstractDeclarator {
+    Ptr(P<Pointer>),
+    // TODO: handle direct abstract declarators
+}
+
+#[derive(Clone, Debug)]
+pub struct Ty {
+    pub specifier_qualifier_list: P<SpecifierQualifierList>,
+    pub abstract_declarator: Option<P<AbstractDeclarator>>,
+}
+
+impl fmt::Display for Ty {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: I am lazy
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Expr {
+    Identifier(Span, String),
+    Constant(Span, P<Constant>),
+    Literal(Span, P<StringLiteral>),
+    GenericSelection(Span, P<Expr>, Vec<P<GenericAssociation>>),
+    Seq(Span, Vec<P<Expr>>),
+    UnaryOp(Span, UnaryOpKind, P<Expr>),
+    BinOp(Span, BinOpKind, P<Expr>, P<Expr>),
+    Ternary(Span, P<Expr>, P<Expr>, P<Expr>),
+    Index(Span, P<Expr>, P<Expr>),
+    Call(Span, P<Expr>, Option<Vec<P<Expr>>>), // TODO: Think about how to store function call arguments
+    Access(Span, bool, P<Expr>, String),
+}
+
+impl fmt::Display for Expr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Identifier(_, s) => write!(f, "{s}"),
+            Self::Constant(_, p) => write!(f, "{p}"),
+            Self::Literal(_, p) => write!(f, "{p}"),
+            Self::Seq(_, ps) => write!(f, "{}", ps[0]),
+            Self::BinOp(_, bin_op_kind, l, r) => write!(f, "{} {} {}", l, bin_op_kind, r),
+            Self::Ternary(_, p, p1, p2) => write!(f, "({}) ? ({}) : ({})", p, p1, p2),
+            Self::UnaryOp(_, unary_op_kind, p) => match unary_op_kind {
+                UnaryOpKind::PostInc | UnaryOpKind::PostDec => {
+                    write!(f, "({}){}", p, unary_op_kind)
+                }
+                _ => write!(f, "{}({})", unary_op_kind, p),
+            },
+            Self::Index(_, base, index) => write!(f, "({})[{}]", base, index),
+            Self::Call(_, p, _todo) => write!(f, "{p}()"),
+            Self::Access(_, arrow, p, p1) => {
+                write!(f, "({}){}{}", p, if *arrow { "->" } else { "." }, p1)
+            }
+            Self::GenericSelection(_, p, ps) => {
+                write!(f, "_Generic ({}, {:#?})", p, ps)
+            }
+        }
+    }
+}

--- a/bsc-parse/src/grammar.lalrpop
+++ b/bsc-parse/src/grammar.lalrpop
@@ -1,0 +1,10 @@
+use std::str::FromStr;
+
+grammar;
+
+pub Term: i32 = {
+    <n:Num> => n,
+    "(" <t:Term> ")" => t,
+};
+
+Num: i32 = <s:r"[0-9]+"> => i32::from_str(s).unwrap();

--- a/bsc-parse/src/grammar.lalrpop
+++ b/bsc-parse/src/grammar.lalrpop
@@ -1,10 +1,18 @@
-use std::str::FromStr;
+use bsc_lexer::TokenKind;
 
 grammar;
 
-pub Term: i32 = {
-    <n:Num> => n,
-    "(" <t:Term> ")" => t,
+pub Program = <Constant*>;
+
+Constant = {
+    "num"
 };
 
-Num: i32 = <s:r"[0-9]+"> => i32::from_str(s).unwrap();
+extern {
+    type Location = usize;
+    type Error = bsc_lexer::LexingError;
+
+    enum TokenKind {
+        "num" => TokenKind::Identifier(<String>),
+    }
+}

--- a/bsc-parse/src/grammar.lalrpop
+++ b/bsc-parse/src/grammar.lalrpop
@@ -1,18 +1,271 @@
-use bsc_lexer::TokenKind;
+use bsc_lexer::{LexingError, TokenKind};
+use crate::ast::*;
+use lalrpop_util::ErrorRecovery;
 
-grammar;
+grammar<'err>(errors: &'err mut Vec<ErrorRecovery<usize, TokenKind, LexingError>>);
 
-pub Program = <Constant*>;
+/// Generic list parsing
+///
+/// T: The rule to parse
+/// d: The delimiter
+GenericList<T, d>: Vec<T> = {
+    <mut v:(<T> d)*> <e:T> => { v.push(e); v }
+}
 
-Constant = {
-    "num"
-};
+/// Generic list specialization on ","
+Comma<T> = GenericList<T, ",">;
+
+pub TranslationUnit = <PrimaryExpr>;
+
+PrimaryExpr: P<Expr> = {
+    <l:@L> <i:id> <r:@R> => P(Expr::Identifier(l..r, i)),
+    <l:@L> <c:Constant> <r:@R> => P(Expr::Constant(l..r, c)),
+    <l:@L> <li:Literal> <r:@R> => P(Expr::Literal(l..r, li)),
+    "(" <Expr> ")",
+    <GenericSelection>,
+}
+
+GenericSelection: P<Expr> = {
+    <l:@L> generic "(" <ae:AssignmentExpr> "," <al:Comma<GenericAssociation>> ")" <r:@R> => {
+        P(Expr::GenericSelection(l..r, ae, al))
+    },
+}
+
+GenericAssociation: P<GenericAssociation> = {
+    <l:@L> <ty:TypeName> ":" <ae:AssignmentExpr> <r:@R> => {
+        P(GenericAssociation { span: l..r, association_ty: AssociationTy::Ty(ty), expr: ae })
+    },
+    <l:@L> default ":" <ae:AssignmentExpr> <r:@R> => {
+        P(GenericAssociation { span: l..r, association_ty: AssociationTy::Default, expr: ae })
+    },
+}
+
+Constant: P<Constant> = {
+    int_lit => P(Constant::Integer(<>))
+}
+
+Literal: P<StringLiteral> = {
+    <l:lit> => P(StringLiteral::StringLiteral(l.value)),
+    func_name => P(StringLiteral::FuncName)
+}
+
+Expr: P<Expr> = {
+    <l:@L> <v:Comma<AssignmentExpr>> <r:@R> => P(Expr::Seq(l..r, v)),
+}
+
+AssignmentExpr: P<Expr> = {
+    <ConditionalExpr>,
+}
+
+ConditionalExpr: P<Expr> = {
+    <LogicalOrExpr>,
+    <l:@L> <cond:LogicalOrExpr> "?" <true_case:Expr> ":" <false_case:ConditionalExpr> <r:@R> => P(Expr::Ternary(l..r, cond, true_case, false_case)),
+}
+
+LogicalOrExpr: P<Expr> = {
+    <LogicalAndExpr>,
+    <l:@L> <left:LogicalOrExpr> "||" <right:LogicalAndExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::LogicalOr, left, right)),
+}
+
+LogicalAndExpr: P<Expr> = {
+    <InclusiveOrExpr>,
+    <l:@L> <left:LogicalAndExpr> "&&" <right:InclusiveOrExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::LogicalAnd, left, right)),
+}
+
+InclusiveOrExpr: P<Expr> = {
+    <ExclusiveOrExpr>,
+    <l:@L> <left:InclusiveOrExpr> "|" <right:ExclusiveOrExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::BitwiseOr, left, right)),
+}
+
+ExclusiveOrExpr: P<Expr> = {
+    <AndExpr>,
+    <l:@L> <left:ExclusiveOrExpr> "^" <right:AndExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::BitwiseXor, left, right)),
+}
+
+AndExpr: P<Expr> = {
+    <EqualityExpr>,
+    <l:@L> <left:AndExpr> "&" <right:EqualityExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::BitwiseAnd, left, right)),
+}
+
+EqualityExpr: P<Expr> = {
+    <RelationalExpr>,
+    <l:@L> <left:EqualityExpr> "==" <right:RelationalExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::Eq, left, right)),
+    <l:@L> <left:EqualityExpr> "!=" <right:RelationalExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::Neq, left, right)),
+}
+
+RelationalExpr: P<Expr> = {
+    <ShiftExpr>,
+    <l:@L> <left:RelationalExpr> "<" <right:ShiftExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::Less, left, right)),
+    <l:@L> <left:RelationalExpr> ">" <right:ShiftExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::Great, left, right)),
+    <l:@L> <left:RelationalExpr> "<=" <right:ShiftExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::LessEq, left, right)),
+    <l:@L> <left:RelationalExpr> ">=" <right:ShiftExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::GreatEq, left, right)),
+}
+
+ShiftExpr: P<Expr> = {
+    <AdditiveExpr>,
+    <l:@L> <left:ShiftExpr> "<<" <right:AdditiveExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::ShiftLeft, left, right)),
+    <l:@L> <left:ShiftExpr> ">>" <right:AdditiveExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::ShiftRight, left, right)),
+}
+
+AdditiveExpr: P<Expr> = {
+    <MultiplcativeExpr>,
+    <l:@L> <left:AdditiveExpr> "+" <right:MultiplcativeExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::Add, left, right)),
+    <l:@L> <left:AdditiveExpr> "-" <right:MultiplcativeExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::Sub, left, right)),
+}
+
+MultiplcativeExpr: P<Expr> = {
+    <CastExpr>,
+    <l:@L> <left:MultiplcativeExpr> "*" <right:CastExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::Mul, left, right)),
+    <l:@L> <left:MultiplcativeExpr> "/" <right:CastExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::Div, left, right)),
+    <l:@L> <left:MultiplcativeExpr> "%" <right:CastExpr> <r:@R> => P(Expr::BinOp(l..r, BinOpKind::Mod, left, right)),
+}
+
+CastExpr: P<Expr> = {
+    <UnaryExpr>,
+    // TODO: cast expr
+}
+
+UnaryExpr: P<Expr> = {
+    <PostfixExpr>,
+    <l:@L> "++" <e:UnaryExpr> <r:@R> => P(Expr::UnaryOp(l..r, UnaryOpKind::PreInc, e)),
+    <l:@L> "--" <e:UnaryExpr> <r:@R> => P(Expr::UnaryOp(l..r, UnaryOpKind::PreDec, e)),
+    <l:@L> "&" <e:CastExpr> <r:@R> => P(Expr::UnaryOp(l..r, UnaryOpKind::Ref, e)),
+    <l:@L> "*" <e:CastExpr> <r:@R> => P(Expr::UnaryOp(l..r, UnaryOpKind::Deref, e)),
+    <l:@L> "+" <e:CastExpr> <r:@R> => P(Expr::UnaryOp(l..r, UnaryOpKind::Plus, e)),
+    <l:@L> "-" <e:CastExpr> <r:@R> => P(Expr::UnaryOp(l..r, UnaryOpKind::Minus, e)),
+    <l:@L> "~" <e:CastExpr> <r:@R> => P(Expr::UnaryOp(l..r, UnaryOpKind::Neg, e)),
+    <l:@L> "!" <e:CastExpr> <r:@R> => P(Expr::UnaryOp(l..r, UnaryOpKind::Not, e)),
+    <l:@L> sizeof <e:UnaryExpr> <r:@R> => P(Expr::UnaryOp(l..r, UnaryOpKind::Sizeof, e)),
+    // TODO: sizeof(typename) and alignof(typename)
+}
+
+PostfixExpr: P<Expr> = {
+    <PrimaryExpr>,
+    <l:@L> <p:PostfixExpr> "[" <e:Expr> "]" <r:@R> => P(Expr::Index(l..r, p, e)),
+    <l:@L> <p:PostfixExpr> "(" ")" <r:@R> => P(Expr::Call(l..r, p, None)),
+    <l:@L> <p:PostfixExpr> "(" <args:Comma<AssignmentExpr>> ")" <r:@R> => P(Expr::Call(l..r, p, Some(args))),
+    <l:@L> <p:PostfixExpr> "." <i:id> <r:@R> => P(Expr::Access(l..r, false, p, i)),
+    <l:@L> <p:PostfixExpr> "->" <i:id> <r:@R> => P(Expr::Access(l..r, true, p, i)),
+    <l:@L> <p:PostfixExpr> "++" <r:@R> => P(Expr::UnaryOp(l..r, UnaryOpKind::PostInc, p)),
+    <l:@L> <p:PostfixExpr> "--" <r:@R> => P(Expr::UnaryOp(l..r, UnaryOpKind::PostDec, p)),
+    // <l:@L> "(" <ty:TypeName> ")" "{"  "}" =>
+}
+
+TypeSpecifier: P<TypeSpecifier> = {
+    void => P(TypeSpecifier::Void),
+    char => P(TypeSpecifier::Char),
+    short => P(TypeSpecifier::Short),
+    int => P(TypeSpecifier::Int),
+    long => P(TypeSpecifier::Long),
+    float => P(TypeSpecifier::Float),
+    double => P(TypeSpecifier::Double),
+    signed => P(TypeSpecifier::Signed),
+    unsigned => P(TypeSpecifier::Unsigned),
+    bool => P(TypeSpecifier::Bool),
+    complex => P(TypeSpecifier::Complex),
+    imaginary => P(TypeSpecifier::Imaginary),
+}
+
+TypeQualifier: P<TypeQualifier> = {
+    const => P(TypeQualifier::Const),
+    restrict => P(TypeQualifier::Restrict),
+    volatile => P(TypeQualifier::Volatile),
+    atomic => P(TypeQualifier::Atomic),
+}
+
+SpecifierQualifierList: P<SpecifierQualifierList> = {
+    <ts:TypeSpecifier> <mut sql:SpecifierQualifierList> => {
+        sql.specifiers.push(ts);
+        sql
+    },
+    <ts:TypeSpecifier> => P(SpecifierQualifierList { specifiers: vec![ts], qualifiers: vec![] }),
+    <tq:TypeQualifier> <mut sql:SpecifierQualifierList> => {
+        sql.qualifiers.push(tq);
+        sql
+    },
+    <tq:TypeQualifier> => P(SpecifierQualifierList { specifiers: vec![], qualifiers: vec![tq] }),
+}
+
+Pointer: P<Pointer> = {
+    "*" <quals:TypeQualifier+> <mut p:Pointer> => {
+        p.indirections.push(Indirection { qualifiers: quals });
+        p
+    },
+    "*" <TypeQualifier+> => P(Pointer { indirections: vec![Indirection { qualifiers: <> }] }),
+    "*" <mut p:Pointer> => { p.indirections.push(Indirection::default()); p },
+    "*" => P(Pointer { indirections: vec![Indirection::default()] })
+}
+
+AbstractDeclarator: P<AbstractDeclarator> = {
+    <Pointer> => P(AbstractDeclarator::Ptr(<>)),
+}
+
+// TODO: handle direct abstract declarators
+
+TypeName: P<Ty> = {
+    <sql:SpecifierQualifierList> <ad:AbstractDeclarator> => P(Ty { specifier_qualifier_list: sql, abstract_declarator: Some(ad) }),
+    <SpecifierQualifierList> => P(Ty { specifier_qualifier_list: <>, abstract_declarator: None }),
+}
 
 extern {
     type Location = usize;
     type Error = bsc_lexer::LexingError;
 
     enum TokenKind {
-        "num" => TokenKind::Identifier(<String>),
+        atomic    => TokenKind::Atomic,
+        bool      => TokenKind::PrimitiveBool,
+        char      => TokenKind::Char,
+        complex   => TokenKind::Complex,
+        const     => TokenKind::Const,
+        default   => TokenKind::Default,
+        double    => TokenKind::Double,
+        float     => TokenKind::Float,
+        func_name => TokenKind::FuncName,
+        generic   => TokenKind::Generic,
+        id        => TokenKind::Identifier(<String>),
+        imaginary => TokenKind::Imaginary,
+        int       => TokenKind::Int,
+        int_lit   => TokenKind::Constant(bsc_lexer::ConstantKind::Integer(<u64>)),
+        lit       => TokenKind::StringLiteral(<bsc_lexer::StringLiteral>),
+        long      => TokenKind::Long,
+        restrict   => TokenKind::Restrict,
+        short     => TokenKind::Short,
+        signed    => TokenKind::Signed,
+        sizeof    => TokenKind::Sizeof,
+        unsigned  => TokenKind::Unsigned,
+        void      => TokenKind::Void,
+        volatile  => TokenKind::Volatile,
+        "!"       => TokenKind::Bang,
+        "!="      => TokenKind::NotEqual,
+        "%"       => TokenKind::Mod,
+        "&"       => TokenKind::Ampersand,
+        "&&"      => TokenKind::LogicalAnd,
+        "("       => TokenKind::LeftParen,
+        ")"       => TokenKind::RightParen,
+        "*"       => TokenKind::Star,
+        "+"       => TokenKind::Plus,
+        "+"       => TokenKind::Plus,
+        "++"      => TokenKind::Inc,
+        ","       => TokenKind::Comma,
+        "-"       => TokenKind::Minus,
+        "--"      => TokenKind::Dec,
+        "->"      => TokenKind::PointerAccess,
+        "."       => TokenKind::Dot,
+        "/"       => TokenKind::Div,
+        ":"       => TokenKind::Colon,
+        "<"       => TokenKind::LessThan,
+        "<<"      => TokenKind::LeftShift,
+        "<="      => TokenKind::LessThanEqual,
+        "=="      => TokenKind::Equal,
+        ">"       => TokenKind::GreaterThan,
+        ">="      => TokenKind::GreaterThanEqual,
+        ">>"      => TokenKind::RightShift,
+        "?"       => TokenKind::TernaryOp,
+        "["       => TokenKind::LeftBracket,
+        "]"       => TokenKind::RightBracket,
+        "^"       => TokenKind::Xor,
+        "|"       => TokenKind::BinaryOr,
+        "||"      => TokenKind::LogicalOr,
+        "~"       => TokenKind::Neg,
     }
 }

--- a/bsc-parse/src/lib.rs
+++ b/bsc-parse/src/lib.rs
@@ -1,14 +1,1 @@
-lalrpop_util::lalrpop_mod!(grammar);
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn grammar_test() {
-        assert!(grammar::TermParser::new().parse("22").is_ok());
-        assert!(grammar::TermParser::new().parse("(22)").is_ok());
-        assert!(grammar::TermParser::new().parse("((((22))))").is_ok());
-        assert!(grammar::TermParser::new().parse("((22)").is_err());
-    }
-}
+lalrpop_util::lalrpop_mod!(pub grammar);

--- a/bsc-parse/src/lib.rs
+++ b/bsc-parse/src/lib.rs
@@ -1,0 +1,14 @@
+lalrpop_util::lalrpop_mod!(grammar);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grammar_test() {
+        assert!(grammar::TermParser::new().parse("22").is_ok());
+        assert!(grammar::TermParser::new().parse("(22)").is_ok());
+        assert!(grammar::TermParser::new().parse("((((22))))").is_ok());
+        assert!(grammar::TermParser::new().parse("((22)").is_err());
+    }
+}

--- a/bsc-parse/src/lib.rs
+++ b/bsc-parse/src/lib.rs
@@ -1,1 +1,4 @@
+pub mod ast;
+pub mod visit;
+
 lalrpop_util::lalrpop_mod!(pub grammar);

--- a/bsc-parse/src/visit.rs
+++ b/bsc-parse/src/visit.rs
@@ -1,0 +1,106 @@
+use crate::ast;
+
+pub trait Visitor: Sized {
+    fn visit_expr(&mut self, expr: &ast::Expr) {
+        walk_expr(self, &expr);
+    }
+
+    fn visit_constant(&mut self, _: &ast::Constant) {
+        /* Nothing */
+    }
+
+    fn visit_identifier(&mut self, _: String) {
+        /* Nothing */
+    }
+
+    fn visit_literal(&mut self, lit: &ast::StringLiteral) {
+        if let ast::StringLiteral::StringLiteral(s) = lit.clone() {
+            self.visit_identifier(s);
+        }
+    }
+
+    fn visit_generic_selection(
+        &mut self,
+        base: &ast::Expr,
+        associations: Vec<&ast::GenericAssociation>,
+    ) {
+        self.visit_expr(base);
+        associations
+            .iter()
+            .for_each(|assoc| self.visit_generic_association(*assoc));
+    }
+
+    fn visit_generic_association(&mut self, assoc: &ast::GenericAssociation) {
+        if let ast::AssociationTy::Ty(_ty) = &assoc.association_ty {
+            // TODO
+        }
+
+        self.visit_expr(&assoc.expr);
+    }
+
+    fn visit_bin_op(&mut self, _: &ast::BinOpKind, l: &ast::Expr, r: &ast::Expr) {
+        self.visit_expr(l);
+        self.visit_expr(r);
+    }
+
+    fn visit_seq(&mut self, exprs: Vec<&ast::Expr>) {
+        exprs.iter().for_each(|expr| self.visit_expr(*expr));
+    }
+
+    fn visit_unary_op(&mut self, _: &ast::UnaryOpKind, expr: &ast::Expr) {
+        self.visit_expr(expr);
+    }
+
+    fn visit_ternary(&mut self, cond: &ast::Expr, branch: &ast::Expr, no_branch: &ast::Expr) {
+        self.visit_expr(cond);
+        self.visit_expr(branch);
+        self.visit_expr(no_branch);
+    }
+
+    fn visit_index(&mut self, expr: &ast::Expr, index: &ast::Expr) {
+        self.visit_expr(expr);
+        self.visit_expr(index);
+    }
+
+    fn visit_call(&mut self, expr: &ast::Expr, args: Option<Vec<&ast::Expr>>) {
+        self.visit_expr(expr);
+
+        if let Some(args) = args {
+            self.visit_seq(args);
+        }
+    }
+
+    fn visit_access(&mut self, _: bool, expr: &ast::Expr, field: String) {
+        self.visit_expr(expr);
+        self.visit_identifier(field);
+    }
+}
+
+fn walk_expr<V: Visitor>(v: &mut V, expr: &ast::Expr) {
+    match expr {
+        ast::Expr::Identifier(_, id) => v.visit_identifier(id.clone()),
+        ast::Expr::Constant(_, constant) => v.visit_constant(constant),
+        ast::Expr::Literal(_, literal) => v.visit_literal(literal),
+        ast::Expr::GenericSelection(_, base, associations) => v.visit_generic_selection(
+            &base,
+            associations.iter().map(|assoc| &**assoc).collect::<Vec<_>>(),
+        ),
+        ast::Expr::Seq(_, exprs) => {
+            v.visit_seq(exprs.iter().map(|expr| &**expr).collect::<Vec<_>>());
+        },
+        ast::Expr::UnaryOp(_, kind, expr) => v.visit_unary_op(kind, expr),
+        ast::Expr::BinOp(_, kind, l, r) => v.visit_bin_op(kind, &l, &r),
+        ast::Expr::Ternary(_, cond, branch, no_branch) => v.visit_ternary(cond, branch, no_branch),
+        ast::Expr::Index(_, expr, index) => v.visit_index(expr, index),
+        ast::Expr::Call(_, expr, args) => {
+            let mut params = None;
+
+            if let Some(args) = args {
+                params = Some(args.iter().map(|arg| &**arg).collect::<Vec<_>>());
+            }
+
+            v.visit_call(expr, params);
+        },
+        ast::Expr::Access(_, ptr, expr, field) => v.visit_access(*ptr, expr, field.clone()),
+    }
+}

--- a/bsc/Cargo.toml
+++ b/bsc/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-bsc-lexer = { path = "../bsc-lexer", features = ["dummy", "logos"] }
+bsc-lexer = { path = "../bsc-lexer", features = ["logos"] }
 bsc-parse = { path = "../bsc-parse" }

--- a/bsc/Cargo.toml
+++ b/bsc/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 bsc-lexer = { path = "../bsc-lexer", features = ["dummy", "logos"] }
+bsc-parse = { path = "../bsc-parse" }

--- a/bsc/src/main.rs
+++ b/bsc/src/main.rs
@@ -1,10 +1,110 @@
 use bsc_lexer::{Lexer, logos::LogosLexer};
-use bsc_parse::grammar;
+use bsc_parse::{grammar, visit::Visitor};
+
+struct PPVisitor;
+
+impl Visitor for PPVisitor {
+    fn visit_constant(&mut self, val: &bsc_parse::ast::Constant) {
+        match val {
+            bsc_parse::ast::Constant::Integer(n) => print!("{n}"),
+            bsc_parse::ast::Constant::Float(n) => print!("{n}"),
+        }
+    }
+
+    fn visit_identifier(&mut self, ident: String) {
+        print!("{ident}")
+    }
+
+    fn visit_literal(&mut self, lit: &bsc_parse::ast::StringLiteral) {
+        if let bsc_parse::ast::StringLiteral::StringLiteral(s) = lit.clone() {
+            print!("\"");
+            self.visit_identifier(s);
+            print!("\"");
+        } else {
+            print!("__func__");
+        }
+    }
+
+    fn visit_bin_op(&mut self, kind: &bsc_parse::ast::BinOpKind, l: &bsc_parse::ast::Expr, r: &bsc_parse::ast::Expr) {
+        self.visit_expr(l);
+        print!(" {kind} ");
+        self.visit_expr(r);
+    }
+
+    fn visit_seq(&mut self, exprs: Vec<&bsc_parse::ast::Expr>) {
+        for i in 0..exprs.len() {
+            self.visit_expr(exprs[i]);
+
+            if i != exprs.len() - 1 {
+                print!(", ")
+            }
+        }
+    }
+
+    fn visit_unary_op(&mut self, kind: &bsc_parse::ast::UnaryOpKind, expr: &bsc_parse::ast::Expr) {
+        print!("{kind}");
+        self.visit_expr(expr);
+    }
+
+    fn visit_ternary(&mut self, cond: &bsc_parse::ast::Expr, branch: &bsc_parse::ast::Expr, no_branch: &bsc_parse::ast::Expr) {
+        self.visit_expr(cond);
+        print!(" ? ");
+        self.visit_expr(branch);
+        print!(" : ");
+        self.visit_expr(no_branch);
+    }
+
+    fn visit_index(&mut self, expr: &bsc_parse::ast::Expr, index: &bsc_parse::ast::Expr) {
+        self.visit_expr(expr);
+        print!("[");
+        self.visit_expr(index);
+        print!("]");
+    }
+
+    fn visit_call(&mut self, expr: &bsc_parse::ast::Expr, args: Option<Vec<&bsc_parse::ast::Expr>>) {
+        self.visit_expr(expr);
+
+        print!("(");
+        if let Some(args) = args {
+            self.visit_seq(args);
+        }
+        print!(")");
+    }
+
+    fn visit_access(&mut self, is_ptr: bool, expr: &bsc_parse::ast::Expr, field: String) {
+        self.visit_expr(expr);
+
+        if is_ptr {
+            print!("->");
+        } else {
+            print!(".");
+        }
+
+        self.visit_identifier(field);
+    }
+}
 
 fn main() {
-    let res = grammar::ProgramParser::new()
-        .parse(LogosLexer::new("test toto tata"))
+    // let mut errors = Vec::new();
+    // let res = grammar::TranslationUnitParser::new()
+    //     .parse(
+    //         &mut errors,
+    //         LogosLexer::new(r#"(_Generic (toto, default : test))"#),
+    //     )
+    //     .unwrap();
+
+    // println!("{:?}", errors);
+    // println!("{}", res);
+    // println!("{:?}", res);
+
+    let mut errors = Vec::new();
+    let mut res = grammar::TranslationUnitParser::new()
+        .parse(&mut errors, LogosLexer::new(r#"(expr.field, expr->field, toto(), toto(tata, tutu)[thing])"#))
         .unwrap();
 
-    println!("{:?}", res);
+    let mut pp_visitor = PPVisitor;
+    pp_visitor.visit_expr(&mut res);
+
+    // println!("{:?}", errors);
+    // println!("{:?}", res);
 }

--- a/bsc/src/main.rs
+++ b/bsc/src/main.rs
@@ -1,17 +1,10 @@
-use bsc_lexer::{Lexer, dummy::DummyLexer, logos::LogosLexer};
+use bsc_lexer::{Lexer, logos::LogosLexer};
+use bsc_parse::grammar;
 
 fn main() {
-    let input = "123 456 789";
-    let dummy_lexer = DummyLexer::new(input);
+    let res = grammar::ProgramParser::new()
+        .parse(LogosLexer::new("test toto tata"))
+        .unwrap();
 
-    for tok in dummy_lexer {
-        println!("{:?}", tok);
-    }
-
-    let input = r#"int main(void) { printf(u8"Hello," " World!\n"); return 42; }"#;
-    let logos_lexer = LogosLexer::new(input);
-
-    for tok in logos_lexer {
-        println!("{:?}", tok);
-    }
+    println!("{:?}", res);
 }


### PR DESCRIPTION
This PR provides a basic setup for the `bsc-parse` module, which will hold the compiler's parser entrypoint.
The parser is a copy of lalrpop's basic usage example. It is meant to be modified over time.